### PR TITLE
Patch 1

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,14 +1,15 @@
 Package.describe({
   name: "wolves:bourbon",
   summary: "Meteor 0.9.x - Bourbon is a simple and lightweight mixin library for Sass.",
-  version: "0.7.1",
+  version: "0.7.0",
   git: "https://github.com/wolvesio/meteor-bourbon"
 });
 
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.0');
-  api.use('fourseven:scss@1.0.0');
+  api.use('fourseven:scss@0.9.5');
   api.addFiles([
+    '_bourbon.scss',
     "settings/_prefixer.scss",
     "settings/_px-to-em.scss",
     // Custom Helpers
@@ -75,8 +76,7 @@ Package.onUse(function(api) {
     "addons/_triangle.scss",
     "addons/_word-wrap.scss",
     // Soon to be deprecated Mixins
-    "_bourbon-deprecated-upcoming.scss",
-    '_bourbon.scss'
+    "_bourbon-deprecated-upcoming.scss"
   ], 'server', {
     isAsset: true
   });

--- a/package.js
+++ b/package.js
@@ -1,15 +1,14 @@
 Package.describe({
   name: "wolves:bourbon",
   summary: "Meteor 0.9.x - Bourbon is a simple and lightweight mixin library for Sass.",
-  version: "0.7.0",
+  version: "0.7.1",
   git: "https://github.com/wolvesio/meteor-bourbon"
 });
 
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.0');
-  api.use('fourseven:scss@0.9.5');
+  api.use('fourseven:scss@1.0.0');
   api.addFiles([
-    '_bourbon.scss',
     "settings/_prefixer.scss",
     "settings/_px-to-em.scss",
     // Custom Helpers
@@ -76,7 +75,8 @@ Package.onUse(function(api) {
     "addons/_triangle.scss",
     "addons/_word-wrap.scss",
     // Soon to be deprecated Mixins
-    "_bourbon-deprecated-upcoming.scss"
+    "_bourbon-deprecated-upcoming.scss",
+    '_bourbon.scss'
   ], 'server', {
     isAsset: true
   });

--- a/package.js
+++ b/package.js
@@ -7,9 +7,8 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('METEOR@0.9.0');
-  api.use('fourseven:scss@0.9.5');
+  api.use('fourseven:scss@1.0.0');
   api.addFiles([
-    '_bourbon.scss',
     "settings/_prefixer.scss",
     "settings/_px-to-em.scss",
     // Custom Helpers
@@ -76,7 +75,8 @@ Package.onUse(function(api) {
     "addons/_triangle.scss",
     "addons/_word-wrap.scss",
     // Soon to be deprecated Mixins
-    "_bourbon-deprecated-upcoming.scss"
+    "_bourbon-deprecated-upcoming.scss",
+    '_bourbon.scss'
   ], 'server', {
     isAsset: true
   });

--- a/versions.json
+++ b/versions.json
@@ -2,18 +2,18 @@
   "dependencies": [
     [
       "fourseven:scss",
-      "0.9.5"
+      "1.0.0"
     ],
     [
       "meteor",
-      "1.0.3"
+      "1.1.3"
     ],
     [
       "underscore",
-      "1.0.0"
+      "1.0.1"
     ]
   ],
   "pluginDependencies": [],
-  "toolVersion": "meteor-tool@1.0.30",
+  "toolVersion": "meteor-tool@1.0.35",
   "format": "1.0"
 }

--- a/versions.json
+++ b/versions.json
@@ -2,18 +2,18 @@
   "dependencies": [
     [
       "fourseven:scss",
-      "1.0.0"
+      "0.9.5"
     ],
     [
       "meteor",
-      "1.1.3"
+      "1.0.3"
     ],
     [
       "underscore",
-      "1.0.1"
+      "1.0.0"
     ]
   ],
   "pluginDependencies": [],
-  "toolVersion": "meteor-tool@1.0.35",
+  "toolVersion": "meteor-tool@1.0.30",
   "format": "1.0"
 }


### PR DESCRIPTION
I've had problems getting this to work (even with restarting the server, which is always necessary), I think because the build process breaks if you try to include the root SCSS ('_bourbon.scss') before the other scss files it tries to import have been added.  This can possibly be avoided by starting up the server without any `@import` statements, stopping it, adding the `@import` back in and then restarting, but this way round that's not necessary.  Also bumped fourseven:scss to 1.0.0.